### PR TITLE
gl crashes on win32 with valid context

### DIFF
--- a/Generator.hs
+++ b/Generator.hs
@@ -456,7 +456,7 @@ mkFFI fm = Module "Graphics.GL.Internal.FFI" export body where
 
 invokers :: Signature -> [Body]
 invokers v =
-  [ Code $ printf "foreign import ccall \"dynamic\" %s :: FunPtr (%s) -> %s" nd v' v'
+  [ Code $ printf "foreign import stdcall \"dynamic\" %s :: FunPtr (%s) -> %s" nd v' v'
   , Function ni (printf "MonadIO m => FunPtr (%s) -> %s" v' v) $
       printf "fp %s = liftIO (%s fp %s)" params nd params
   ] where


### PR DESCRIPTION
on windows the gl package crashes with access violation even with valid context

see: http://lpaste.net/120306
crashes on line#34