### PR TITLE
Revert "gl crashes on win32 with valid context"

### DIFF
--- a/Generator.hs
+++ b/Generator.hs
@@ -456,7 +456,7 @@ mkFFI fm = Module "Graphics.GL.Internal.FFI" export body where
 
 invokers :: Signature -> [Body]
 invokers v =
-  [ Code $ printf "foreign import stdcall \"dynamic\" %s :: FunPtr (%s) -> %s" nd v' v'
+  [ Code $ printf "foreign import ccall \"dynamic\" %s :: FunPtr (%s) -> %s" nd v' v'
   , Function ni (printf "MonadIO m => FunPtr (%s) -> %s" v' v) $
       printf "fp %s = liftIO (%s fp %s)" params nd params
   ] where


### PR DESCRIPTION
Reverts ekmett/gl#7

The patch is incorrect.